### PR TITLE
Breaking change: MSDParameter rewrite for multi-value parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ pip install --pre msdparser
 
 ## Parsing
 
-`parse_msd` takes a named `file` or `string` argument and yields parameters as named (key, value) tuples:
+`parse_msd` takes a named `file` or `string` argument and yields `MSDParameter` instances:
 
 ```python
 >>> from msdparser import parse_msd
 >>> with open('testdata/Springtime.ssc', 'r', encoding='utf-8') as simfile:
-...     for (key, value) in parse_msd(file=simfile):
-...         if key == 'NOTEDATA': break     # stop at the first chart
-...         if not value: continue          # hide empty values
-...         print(key, '=', repr(value))
+...     for param in parse_msd(file=simfile):
+...         if param.key == 'NOTEDATA': break   # stop at the first chart
+...         if not param.value: continue        # hide empty values
+...         print(param.key, '=', repr(param.value))
 ...
 VERSION = '0.83'
 TITLE = 'Springtime'
@@ -42,9 +42,9 @@ SCROLLS = '0=1'
 LABELS = '0=Song Start'
 ```
 
-## Serializing (v2.0+)
+## Serializing
 
-To serialize key/value pairs back into MSD, construct an `MSDParameter` for each pair and stringify it:
+`MSDParameter` instances stringify back to MSD. They can be created from a sequence of strings:
 
 ```python
 >>> from msdparser import MSDParameter
@@ -56,40 +56,8 @@ To serialize key/value pairs back into MSD, construct an `MSDParameter` for each
 #ARTIST:Kommisar;
 ```
 
-`parse_msd` yields `MSDParameter` instances, so you could read & write MSD in a single loop:
-
-```python
->>> from msdparser import parse_msd, MSDParameter
->>> with open('testdata/Springtime.ssc', 'r') as simfile, open('output.ssc', 'w') as output:
-...     for param in parse_msd(file=simfile):
-...         if param.key == 'SUBTITLE':
-...             param = param._replace(value=param.value + ' (edited)')
-...         output.write(str(param))
-...         output.write('\n')
-```
-
 Prefer to use `MSDParameter` over interpolating the key/value pairs between `#:;` characters yourself. The `str()` implementation inserts escape sequences where required, preventing generation of invalid MSD.
 
 ## Documentation
 
 https://msdparser.readthedocs.io/en/latest/
-
-## The MSD format
-
-In general, MSD key-value pairs look like `#KEY:VALUE;` - the `#` starts a parameter, the first `:` separates the key from the value, and the `;` terminates the value. Keys are not expected to be unique.
-
-Comments start with `//` and persist until the end of the line. They can appear anywhere, including inside values (or even keys).
-
-Keys and values can be blank. The `:` separator can even be omitted, which has the same result as a blank value.
-
-StepMania recovers from a missing `;` if it finds a `#` marker at the start of a line, so this parser does too.
-
-### Escape sequences
-
-Modern applications of MSD (such as the SM and SSC formats) have escape sequences: any special character (`:`, `;`, `\`) or comment initializer (`//`) can be treated as literal text by prefixing it with a `\`. This behavior is enabled by default.
-
-Older applications like DWI treat backslashes as regular text, and thus do not permit a literal `;` in keys or values, nor `:` in keys. This behavior can be replicated by passing `escapes=False` to `parse_msd` or `MSDParameter.serialize`.
-
-### Multi-value parameters
-
-Some keys (such as the SM format's `STEPS`) are expected to have multiple `:`-separated values. For simplicity, this parser always treats `:` in a value literally, leaving any multi-value semantics up to client code to implement. (In other words, `#KEY:A:B;` deserializes to `('KEY', 'A:B')`, rather than `('KEY', ['A', 'B'])` or similar.)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+2.0.0-beta.2
+~~~~~~~~~~~~
+
+This release significantly changes how multi-value parameters are handled. Unescaped colons
+``:`` after the key are no longer treated as literal text: now a colon _always_ separates
+components, and the key and value are defined as the first and second components. This
+brings **msdparser** into parity with StepMania when unexpected colons appear after a
+parameter's key.
+
+**API change:** :class:`.MSDParameter` is no longer a subclass of ``NamedTuple``. Instead,
+it's a dataclass with :meth:`~.key` and :meth:`~.value` properties that index into a sequence
+of :attr:`~.components`.
+
 2.0.0-beta.1
 ~~~~~~~~~~~~
 
@@ -9,20 +22,20 @@ absence of this feature was technically a bug in the spec (escapes have been
 supported since the SM format!), this is still a breaking change, hence the
 major version bump.
 
-Backslash escapes can be disabled by passing :code:`escapes=False` to :code:`parse_msd`,
+Backslash escapes can be disabled by passing :code:`escapes=False` to :func:`.parse_msd`,
 restoring the 1.0.0 behavior and preserving spec-compliant parsing of older
 formats like DWI.
 
-**Feature:** The return type of :func:`parse_msd` has been changed from 
-:code:`Tuple[str, str]` to :class:`MSDParameter`, which is a :code:`NamedTuple` of two strings, 
-`key` and `value`. Stringifying an :class:`MSDParameter` interpolates the key/value 
+**Feature:** The return type of :func:`.parse_msd` has been changed from 
+:code:`Tuple[str, str]` to :class:`.MSDParameter`, which is a :code:`NamedTuple` of two strings, 
+`key` and `value`. Stringifying an :class:`.MSDParameter` interpolates the key/value 
 pair into the MSD :code:`#KEY:VALUE;` format, escaping special characters by default.
 
-Existing :func:`parse_msd` client code that expects :code:`(key, value)` tuples should 
+Existing :func:`.parse_msd` client code that expects :code:`(key, value)` tuples should 
 still operate fine, but you can now also access the key/value pair as `key` / 
 `value` properties on the yielded objects.
 
-**Performance:** :func:`parse_msd` has been optimized for most MSD documents,
+**Performance:** :func:`.parse_msd` has been optimized for most MSD documents,
 particularly those containing large blocks of note data.
 
 1.0.0

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 ~~~~~~~~~~~~
 
 This release significantly changes how multi-value parameters are handled. Unescaped colons
-``:`` after the key are no longer treated as literal text: now a colon _always_ separates
+(``:``) after the key are no longer treated as literal text: now a colon _always_ separates
 components, and the key and value are defined as the first and second components. This
 brings **msdparser** into parity with StepMania when unexpected colons appear after a
 parameter's key.

--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -19,16 +19,17 @@ Refer to the table below to decide whether escapes should be left enabled or exp
 ======== ============
 Format   Has escapes?
 -------- ------------
-SM       ✓
+SM       ✓ [1]_
 SMA      ✓
 SSC      ✓
-TXT [1]_ ✓
+TXT [2]_ ✓
 CRS
 DWI
 KSF
 ======== ============
 
-.. [1] Refers to the file ``Data/RandomAttacks.txt`` that comes bundled with StepMania.
+.. [1] Only in StepMania versions 4 and 5 (and their forks). Older versions like 3.9 and forks like OpenITG / NotITG do not support escapes.
+.. [2] Refers to the file ``Data/RandomAttacks.txt`` that comes bundled with StepMania.
 
 Edge cases
 ~~~~~~~~~~
@@ -40,4 +41,14 @@ StepMania recovers from a missing ``;`` if it finds a ``#`` marker at the start 
 Multi-value parameters
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Some keys (such as the SM format's ``NOTES``) are expected to have multiple ``:``-separated values. For simplicity, this parser always treats ``:`` in a value literally, leaving any multi-value semantics up to client code to implement. (In other words, the value of ``#KEY:A:B;`` deserializes to ``'A:B'``, rather than ``['A', 'B']`` or similar.)
+MSD parameters can have multiple values separated by colons, like ``#KEY:VALUE1:VALUE2:...;``. While this feature is used infrequently, it's an important detail for understanding how StepMania treats unescaped colons in a value. For example, specifying a song title as ``#TITLE:rE:Voltagers;`` will cause StepMania to display the title as ``rE``, discarding everything after the unescaped colon.
+
+These are the properties where StepMania expects to find multi-value parameters:
+
+========== ====== ======
+Property   SM     SSC
+---------- ------ ------
+DISPLAYBPM ✓      ✓
+ATTACKS    ✓      ✓
+NOTES      ✓
+========== ====== ======

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,21 +1,21 @@
 msdparser
 =========
 
-Simple MSD parser for Python. MSD is the underlying file format for many rhythm games, most notably both StepMania simfile formats (.sm and .ssc).
+Simple MSD parser for Python. MSD is the underlying file format for a few rhythm games, most notably both StepMania simfile formats (.sm and .ssc).
 
 Parsing
 -------
 
-:func:`.parse_msd` takes a named `file` or `string` argument and yields parameters that can be unpacked as (key, value) tuples:
+:func:`.parse_msd` takes a named `file` or `string` argument and yields :class:`MSDParameter` instances:
 
 .. doctest::
 
     >>> from msdparser import parse_msd
     >>> with open('testdata/Springtime.ssc', 'r', encoding='utf-8') as simfile:
-    ...     for (key, value) in parse_msd(file=simfile):
-    ...         if key == 'NOTEDATA': break     # stop at the first chart
-    ...         if not value: continue          # hide empty values
-    ...         print(key, '=', repr(value))
+    ...     for param in parse_msd(file=simfile):
+    ...         if param.key == 'NOTEDATA': break   # stop at the first chart
+    ...         if not param.value: continue        # hide empty values
+    ...         print(param.key, '=', repr(param.value))
     ...
     VERSION = '0.83'
     TITLE = 'Springtime'
@@ -36,32 +36,20 @@ Parsing
     SCROLLS = '0=1'
     LABELS = '0=Song Start'
 
-Serializing (v2.0+)
--------------------
+Serializing
+-----------
 
-To serialize key/value pairs back into MSD, construct an :class:`.MSDParameter` for each pair and stringify it:
+:class:`.MSDParameter` instances stringify back to MSD. They can be created from a sequence of strings:
 
 .. code-block:: python
 
     >>> from msdparser import MSDParameter
     >>> pairs = [('TITLE', 'Springtime'), ('ARTIST', 'Kommisar')]
     >>> for key, value in pairs:
-    ...     print(str(MSDParameter(key=key, value=value)))
+    ...     print(str(MSDParameter([key, value])))
     ...
     #TITLE:Springtime;
     #ARTIST:Kommisar;
-
-:func:`parse_msd` yields :class:`.MSDParameter` instances, so you could read & write MSD in a single loop:
-
-.. code-block:: python
-
-    >>> from msdparser import parse_msd, MSDParameter
-    >>> with open('testdata/Springtime.ssc', 'r') as simfile, open('output.ssc', 'w') as output:
-    ...     for param in parse_msd(file=simfile):
-    ...         if param.key == 'SUBTITLE':
-    ...             param = param._replace(value=param.value + ' (edited)')
-    ...         output.write(str(param))
-    ...         output.write('\n')
 
 Prefer to use :class:`.MSDParameter` over interpolating the key/value pairs between ``#:;`` characters yourself. The ``str()`` implementation inserts escape sequences where required, preventing generation of invalid MSD.
 

--- a/msdparser/__init__.py
+++ b/msdparser/__init__.py
@@ -35,28 +35,25 @@ class MSDParameter:
     MUST_ESCAPE = ('//', ':', ';')
     
     components: Sequence[str]
-    '''
-    The raw MSD components. Any special substrings are unescaped.
-    
-    This class enforces a minimum of 2 components so that a key & value are
-    always available, even if one or both are blank.
-    '''
-
-    def __post_init__(self):
-        while len(self.components) < 2:
-            self.components = (*self.components, '')
+    '''The raw MSD components. Any special substrings are unescaped.'''
 
     @property
-    def key(self):
+    def key(self) -> Optional[str]:
         '''The first MSD component.'''
-        return self.components[0]
+        try:
+            return self.components[0]
+        except IndexError:
+            return None
 
     @property
-    def value(self):
+    def value(self) -> Optional[str]:
         '''
         The second MSD component, after the key.
         '''
-        return self.components[1]
+        try:
+            return self.components[1]
+        except IndexError:
+            return None
 
     @staticmethod
     def serialize_component(component: str, *, escapes: bool = True) -> str:

--- a/msdparser/__init__.py
+++ b/msdparser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.0-beta.1'
+__version__ = '2.0.0-beta.2'
 
 from dataclasses import dataclass
 from functools import reduce

--- a/msdparser/__init__.py
+++ b/msdparser/__init__.py
@@ -1,10 +1,10 @@
 __version__ = '2.0.0-beta.1'
 
-import enum
+from dataclasses import dataclass
 from functools import reduce
 from io import StringIO
 import re
-from typing import Iterable, Iterator, NamedTuple, Optional, Sequence, TextIO, Tuple, Union
+from typing import Iterable, Iterator, List, NamedTuple, Optional, Sequence, TextIO, Tuple, Union
 
 
 __all__ = ['parse_msd', 'MSDParserError', 'MSDParameter']
@@ -13,15 +13,6 @@ __all__ = ['parse_msd', 'MSDParserError', 'MSDParameter']
 def trailing_newline(line: str):
     end_of_line = len(line.rstrip('\r\n'))
     return line[end_of_line:]
-
-
-class State(enum.Enum):
-    """
-    Encapsulates the high-level state of the MSD parser.
-    """
-    SEEK = enum.auto() # Discard until a '#' is reached
-    KEY = enum.auto() # Read the key until a ':' or ';' is reached
-    VALUE = enum.auto() # Read the value until a ';' is reached
 
 
 class MSDParserError(Exception):
@@ -33,98 +24,94 @@ class MSDParserError(Exception):
     """
 
 
-class MSDParameter(NamedTuple):
-    """
-    A key/value tuple.
+@dataclass
+class MSDParameter:
+    '''
+    An MSD parameter, comprised of a key and some values (usually one).
 
     Stringifying an ``MSDParameter`` converts it back into MSD, escaping
     any backslashes ``\\`` or special substrings.
-    """
-    key: str
-    '''The first MSD component. Any special substrings are unescaped.'''
-    value: str
-    '''The second MSD component. Any special substrings are unescaped.'''
+    '''
+    MUST_ESCAPE = ('//', ':', ';')
+    
+    components: Sequence[str]
+    '''
+    The raw MSD components. Any special substrings are unescaped.
+    
+    This class enforces a minimum of 2 components so that a key & value are
+    always available, even if one or both are blank.
+    '''
 
-    @classmethod
-    def _serialize_component(
-        cls,
-        *,
-        component_name: str,
-        component: str,
-        must_escape: Tuple[str, ...],
-        escapes: bool,
-    ) -> str:
+    def __post_init__(self):
+        while len(self.components) < 2:
+            self.components = (*self.components, '')
+
+    @property
+    def key(self):
+        '''The first MSD component.'''
+        return self.components[0]
+
+    @property
+    def value(self):
+        '''
+        The second MSD component, after the key.
+        '''
+        return self.components[1]
+
+    @staticmethod
+    def serialize_component(component: str, *, escapes: bool = True) -> str:
+        """
+        Serialize an MSD component (key or value).
+
+        By default, backslashes (``\\``) and special substrings (``:``,
+        ``;``, and ``//``) are escaped. When `escapes` is set to False, if
+        the component contains a special substring, this method throws
+        ``ValueError`` to avoid producing invalid MSD.
+        """
         if escapes:
+            # Backslashes must be escaped first to avoid double-escaping
             return reduce(
                 lambda key, esc: key.replace(esc, f'\\{esc}'),
-                ('\\',) + must_escape, # sequence
-                component,   # initial value
+                ('\\',) + MSDParameter.MUST_ESCAPE,
+                component,
             )
-        elif any(esc in component for esc in must_escape):
+        elif any(esc in component for esc in MSDParameter.MUST_ESCAPE):
             raise ValueError(
-                f'{repr(component)}: invalid MSD {component_name} without escapes'
+                f"{repr(component)} can't be serialized without escapes"
             )
         else:
             return component
 
-    def serialize_key(self, *, escapes: bool = True) -> str:
-        """
-        Serialize the key.
-
-        By default, backslashes ``\\`` and special substrings for keys
-        (``:``, ``;`` and ``//``) are escaped. When ``escapes`` is set to
-        False and the key contains a special substring, this method throws
-        ``ValueError`` to avoid producing invalid MSD.
-        """
-        return MSDParameter._serialize_component(
-            component_name='key',
-            component=self.key,
-            must_escape=('//', ':', ';'),
-            escapes=escapes,
-        )
-
-    def serialize_value(self, *, escapes: bool = True) -> str:
-        """
-        Serialize the value.
-        
-        By default, backslashes ``\\`` and special substrings for values
-        (``;`` and ``//``) are escaped. When ``escapes`` is set to False
-        and the key contains a special substring, this method throws
-        ``ValueError`` to avoid producing invalid MSD.
-        """
-        return MSDParameter._serialize_component(
-            component_name='value',
-            component=self.value,
-            must_escape=('//', ';'),
-            escapes=escapes,
-        )
-
-    def serialize(self, *, escapes: bool = True) -> str:
+    def serialize(self, file: TextIO, *, escapes: bool = True):
         """
         Serialize the key/value pair to MSD, including the surrounding
         ``#:;`` characters.
 
-        By default, backslashes ``\\`` and special substrings are escaped.
-        When `escapes` is set to False and the key or value contains a
-        special substring, this method throws ``ValueError`` to avoid
-        producing invalid MSD. See :meth:`serialize_key` and
-        :meth:`serialize_value` for more details.
+        By default, backslashes (``\\``) and special substrings (``//``,
+        ``:``, and ``;``) are escaped. When `escapes` is set to False, if
+        any component contains a special substring, this method throws
+        ``ValueError`` to avoid producing invalid MSD.
         """
-        return (
-            f'#{self.serialize_key(escapes=escapes)}'
-            f':{self.serialize_value(escapes=escapes)};'
-        )
+        last_component = len(self.components) - 1
+        file.write('#')
+        for c, component in enumerate(self.components):
+            file.write(MSDParameter.serialize_component(component, escapes=escapes))
+            if c != last_component:
+                file.write(':')
+        file.write(';')
     
-    def __str__(self) -> str:
-        return self.serialize()
+    def __str__(self, *, escapes: bool = True) -> str:
+        output = StringIO()
+        self.serialize(output, escapes=escapes)
+        return output.getvalue()
 
 
-class ParameterState(object):
+class ParameterState:
     """
     Encapsulates the complete state of the MSD parser, including the partial
     key/value pair.
     """
-    __slots__ = ['key', 'value', 'state', 'ignore_stray_text']
+    __slots__ = ['writing', 'components', 'state', 'ignore_stray_text']
 
     def __init__(self, ignore_stray_text):
         self.ignore_stray_text = ignore_stray_text
@@ -134,28 +121,31 @@ class ParameterState(object):
         """
         Clear the key & value and set the state to SEEK.
         """
-        self.key = StringIO()
-        self.value = StringIO()
-        self.state = State.SEEK
+        self.components: List[StringIO] = []
+        self.writing = False
     
     def write(self, text) -> None:
         """
         Write to the key or value, or handle stray text if seeking.
         """
-        if self.state is State.KEY:
-            self.key.write(text)
-        elif self.state is State.VALUE:
-            self.value.write(text)
+        if self.writing:
+            self.components[-1].write(text)
         elif not self.ignore_stray_text:
             if text and not text.isspace() and text != '\ufeff':
                 raise MSDParserError(f"stray {repr(text)} encountered")
     
+    def next_component(self) -> None:
+        self.writing = True
+        self.components.append(StringIO())
+    
     def complete(self) -> MSDParameter:
         """
-        Return the parameter as a (key, value) tuple and reset to the initial
-        key / value / state.
+        Return the completed :class:`MSDParameter` and reset to the initial
+        state.
         """
-        parameter = MSDParameter(self.key.getvalue(), self.value.getvalue())
+        parameter = MSDParameter(
+            tuple(component.getvalue() for component in self.components)
+        )
         self._reset()
         return parameter
 
@@ -170,7 +160,7 @@ def parse_msd(
     string: Optional[str] = None,
     escapes: bool = True,
     ignore_stray_text: bool = False
-) -> Iterator[Tuple[str, str]]:
+) -> Iterator[MSDParameter]:
     """
     Parse MSD data into a stream of :class:`MSDParameter` objects.
 
@@ -197,7 +187,7 @@ def parse_msd(
     # parameters; otherwise users might try to pass filenames as input strings.
     line_iterator: Iterable[str]
     if isinstance(file_or_string, str):
-        line_iterator = file_or_string.splitlines(True)
+        line_iterator = file_or_string.splitlines(True) # keep line endings
     else:
         line_iterator = file_or_string
 
@@ -207,7 +197,7 @@ def parse_msd(
     for line in line_iterator:
 
         # Handle missing ';' outside of the loop
-        if ps.state is not State.SEEK and line.startswith('#'):
+        if ps.writing and line.startswith('#'):
             yield ps.complete()
         
         # Note data constitutes the vast majority of most MSD files, and
@@ -228,8 +218,8 @@ def parse_msd(
 
             elif char == '#':
                 # Start of the next parameter
-                if ps.state is State.SEEK:
-                    ps.state = State.KEY
+                if not ps.writing:
+                    ps.next_component()
                 # Treat '#' normally elsewhere
                 else:
                     ps.write(char)
@@ -245,16 +235,16 @@ def parse_msd(
 
             elif char == ';':
                 # End of the parameter
-                if ps.state is not State.SEEK:
+                if ps.writing:
                     yield ps.complete()
                 # Otherwise this is a stray character
                 else:
                     ps.write(char)
             
             elif char == ':':
-                # Key-value separator
-                if ps.state is State.KEY:
-                    ps.state = State.VALUE
+                # Key/values separator
+                if ps.writing:
+                    ps.next_component()
                 # Treat ':' normally elsewhere
                 else:
                     ps.write(char)
@@ -270,7 +260,6 @@ def parse_msd(
             else:
                 assert False, 'this branch should never be reached'
 
-
     # Handle missing ';' at the end of the input
-    if ps.state is not State.SEEK:
+    if ps.writing:
         yield ps.complete()

--- a/msdparser/tests/test_module.py
+++ b/msdparser/tests/test_module.py
@@ -103,8 +103,10 @@ class TestParseMSD(unittest.TestCase):
     def test_missing_value(self):
         parse = parse_msd(string='#ABC;#DEF;')
 
-        self.assertEqual(MSDParameter(('ABC', '')), next(parse))
-        self.assertEqual(MSDParameter(('DEF', '')), next(parse))
+        param = next(parse)
+        self.assertEqual(MSDParameter(('ABC',)), param)
+        self.assertIsNone(param.value)
+        self.assertEqual(MSDParameter(('DEF',)), next(parse))
         self.assertRaises(StopIteration, next, parse)
 
     def test_missing_semicolon(self):
@@ -112,16 +114,16 @@ class TestParseMSD(unittest.TestCase):
         
         self.assertEqual(MSDParameter(('A', 'B\nCD')), next(parse))
         self.assertEqual(MSDParameter(('E', 'FGH\n')), next(parse))
-        self.assertEqual(MSDParameter(('IJKL\n', '')), next(parse))
+        self.assertEqual(MSDParameter(('IJKL\n',)), next(parse))
         self.assertEqual(MSDParameter(('M', 'NOP')), next(parse))
         self.assertRaises(StopIteration, next, parse)
     
     def test_missing_value_and_semicolon(self):
         parse = parse_msd(string='#A\n#B\n#C\n')
 
-        self.assertEqual(MSDParameter(('A\n', '')), next(parse))
-        self.assertEqual(MSDParameter(('B\n', '')), next(parse))
-        self.assertEqual(MSDParameter(('C\n', '')), next(parse))
+        self.assertEqual(MSDParameter(('A\n',)), next(parse))
+        self.assertEqual(MSDParameter(('B\n',)), next(parse))
+        self.assertEqual(MSDParameter(('C\n',)), next(parse))
         self.assertRaises(StopIteration, next, parse)
     
     def test_unicode(self):

--- a/msdparser/tests/test_module.py
+++ b/msdparser/tests/test_module.py
@@ -7,46 +7,41 @@ from msdparser import MSDParameter, MSDParserError, parse_msd
 
 class TestMSDParameter(unittest.TestCase):
     def test_constructor(self):
-        param = MSDParameter('key', 'value')
+        param = MSDParameter(('key', 'value'))
         
         self.assertEqual('key', param.key)
         self.assertEqual('value', param.value)
-        self.assertIs(param[0], param.key)
-        self.assertIs(param[1], param.value)
-
-    def test_backwards_compatible_type(self):
-        # Pylance test: replacing (k, v) with MSDParameter(k, v) shouldn't
-        # cause any type errors in client code
-        _: Tuple[str, str] = MSDParameter('key', 'value')
+        self.assertIs(param.components[0], param.key)
+        self.assertIs(param.components[1], param.value)
     
     def test_str_with_escapes(self):
-        param = MSDParameter('key', 'value')
-        evil_param = MSDParameter('ABC:DEF;GHI//JKL\\MNO', 'abc:def;ghi//jkl\\mno')
+        param = MSDParameter(('key', 'value'))
+        evil_param = MSDParameter(('ABC:DEF;GHI//JKL\\MNO', 'abc:def;ghi//jkl\\mno'))
 
         self.assertEqual('#key:value;', str(param))
-        self.assertEqual('#ABC\\:DEF\\;GHI\\//JKL\\\\MNO:abc:def\\;ghi\\//jkl\\\\mno;', str(evil_param))
+        self.assertEqual('#ABC\\:DEF\\;GHI\\//JKL\\\\MNO:abc\\:def\\;ghi\\//jkl\\\\mno;', str(evil_param))
     
     def test_str_without_escapes(self):
-        param = MSDParameter('key', 'value')
-        multi_value_param = MSDParameter('key', 'abc:def')
-        param_with_literal_backslashes = MSDParameter('ABC\\DEF', 'abc\\def')
+        param = MSDParameter(('key', 'value'))
+        multi_value_param = MSDParameter(('key', 'abc', 'def'))
+        param_with_literal_backslashes = MSDParameter(('ABC\\DEF', 'abc\\def'))
         invalid_params = (
             # `:` separator in key
-            MSDParameter('ABC:DEF', 'abcdef'),
+            MSDParameter(('ABC:DEF', 'abcdef')),
             # `;` terminator in key or value
-            MSDParameter('ABC;DEF', 'abcdef'),
-            MSDParameter('ABCDEF', 'abc;def'),
+            MSDParameter(('ABC;DEF', 'abcdef')),
+            MSDParameter(('ABCDEF', 'abc;def')),
             # `//` comment initializer in key or value
-            MSDParameter('ABC//DEF', 'abcdef'),
-            MSDParameter('ABCDEF', 'abc//def'),
+            MSDParameter(('ABC//DEF', 'abcdef')),
+            MSDParameter(('ABCDEF', 'abc//def')),
         )
 
-        self.assertEqual('#key:value;', param.serialize(escapes=False))
-        self.assertEqual('#key:abc:def;', multi_value_param.serialize(escapes=False))
-        self.assertEqual('#ABC\\DEF:abc\\def;', param_with_literal_backslashes.serialize(escapes=False))
+        self.assertEqual('#key:value;', param.__str__(escapes=False))
+        self.assertEqual('#key:abc:def;', multi_value_param.__str__(escapes=False))
+        self.assertEqual('#ABC\\DEF:abc\\def;', param_with_literal_backslashes.__str__(escapes=False))
 
         for invalid_param in invalid_params:
-            self.assertRaises(ValueError, invalid_param.serialize, escapes=False)
+            self.assertRaises(ValueError, invalid_param.__str__, escapes=False)
 
 
 class TestParseMSD(unittest.TestCase):
@@ -67,94 +62,100 @@ class TestParseMSD(unittest.TestCase):
     
     def test_normal_characters(self):
         parse = parse_msd(string='#A1,./\'"[]{\\\\}|`~!@#$%^&*()-_=+ \r\n\t:A1,./\'"[]{\\\\}|`~!@#$%^&*()-_=+ \r\n\t:;')
-        key, value = next(parse)
+        param = next(parse)
 
-        self.assertEqual('A1,./\'"[]{\\}|`~!@#$%^&*()-_=+ \r\n\t', key)
-        self.assertEqual('A1,./\'"[]{\\}|`~!@#$%^&*()-_=+ \r\n\t:', value)
+        self.assertEqual(
+            (
+                'A1,./\'"[]{\\}|`~!@#$%^&*()-_=+ \r\n\t',
+                'A1,./\'"[]{\\}|`~!@#$%^&*()-_=+ \r\n\t',
+                '',
+            ),
+            param.components
+        )
         self.assertRaises(StopIteration, next, parse)
     
     def test_comments(self):
         parse = parse_msd(string='#A// comment //\r\nBC:D// ; \nEF;//#NO:PE;')
         
-        self.assertEqual(('A\r\nBC', 'D\nEF'), next(parse))
+        self.assertEqual(MSDParameter(('A\r\nBC', 'D\nEF')), next(parse))
         self.assertRaises(StopIteration, next, parse)
     
     def test_comment_with_no_newline_at_eof(self):
         parse = parse_msd(string='#ABC:DEF// eof')
 
-        self.assertEqual(('ABC', 'DEF'), next(parse))
+        self.assertEqual(MSDParameter(('ABC', 'DEF')), next(parse))
         self.assertRaises(StopIteration, next, parse)
 
     def test_empty_key(self):
         parse = parse_msd(string='#:ABC;#:DEF;')
 
-        self.assertEqual(('', 'ABC'), next(parse))
-        self.assertEqual(('', 'DEF'), next(parse))
+        self.assertEqual(MSDParameter(('', 'ABC')), next(parse))
+        self.assertEqual(MSDParameter(('', 'DEF')), next(parse))
         self.assertRaises(StopIteration, next, parse)
     
     def test_empty_value(self):
         parse = parse_msd(string='#ABC:;#DEF:;')
 
-        self.assertEqual(('ABC', ''), next(parse))
-        self.assertEqual(('DEF', ''), next(parse))
+        self.assertEqual(MSDParameter(('ABC', '')), next(parse))
+        self.assertEqual(MSDParameter(('DEF', '')), next(parse))
         self.assertRaises(StopIteration, next, parse)
 
     def test_missing_value(self):
         parse = parse_msd(string='#ABC;#DEF;')
 
-        self.assertEqual(('ABC', ''), next(parse))
-        self.assertEqual(('DEF', ''), next(parse))
+        self.assertEqual(MSDParameter(('ABC', '')), next(parse))
+        self.assertEqual(MSDParameter(('DEF', '')), next(parse))
         self.assertRaises(StopIteration, next, parse)
 
     def test_missing_semicolon(self):
         parse = parse_msd(string='#A:B\nCD;#E:FGH\n#IJKL// comment\n#M:NOP')
         
-        self.assertEqual(('A', 'B\nCD'), next(parse))
-        self.assertEqual(('E', 'FGH\n'), next(parse))
-        self.assertEqual(('IJKL\n', ''), next(parse))
-        self.assertEqual(('M', 'NOP'), next(parse))
+        self.assertEqual(MSDParameter(('A', 'B\nCD')), next(parse))
+        self.assertEqual(MSDParameter(('E', 'FGH\n')), next(parse))
+        self.assertEqual(MSDParameter(('IJKL\n', '')), next(parse))
+        self.assertEqual(MSDParameter(('M', 'NOP')), next(parse))
         self.assertRaises(StopIteration, next, parse)
     
     def test_missing_value_and_semicolon(self):
         parse = parse_msd(string='#A\n#B\n#C\n')
 
-        self.assertEqual(('A\n', ''), next(parse))
-        self.assertEqual(('B\n', ''), next(parse))
-        self.assertEqual(('C\n', ''), next(parse))
+        self.assertEqual(MSDParameter(('A\n', '')), next(parse))
+        self.assertEqual(MSDParameter(('B\n', '')), next(parse))
+        self.assertEqual(MSDParameter(('C\n', '')), next(parse))
         self.assertRaises(StopIteration, next, parse)
     
     def test_unicode(self):
         parse = parse_msd(string='#TITLE:実例;\n#ARTIST:楽士;')
         
-        self.assertEqual(('TITLE', '実例'), next(parse))
-        self.assertEqual(('ARTIST', '楽士'), next(parse))
+        self.assertEqual(MSDParameter(('TITLE', '実例')), next(parse))
+        self.assertEqual(MSDParameter(('ARTIST', '楽士')), next(parse))
         self.assertRaises(StopIteration, next, parse)
     
     def test_stray_text(self):
         parse = parse_msd(string='#A:B;n#C:D;')
 
-        self.assertEqual(('A', 'B'), next(parse))
+        self.assertEqual(MSDParameter(('A', 'B')), next(parse))
         self.assertRaises(MSDParserError, next, parse)
     
     def test_stray_semicolon(self):
         parse = parse_msd(string='#A:B;;#C:D;')
 
-        self.assertEqual(('A', 'B'), next(parse))
+        self.assertEqual(MSDParameter(('A', 'B')), next(parse))
         self.assertRaises(MSDParserError, next, parse)
     
     def test_stray_text_with_ignore_stray_text(self):
         parse = parse_msd(string='#A:B;n#C:D;', ignore_stray_text=True)
 
-        self.assertEqual(('A', 'B'), next(parse))
-        self.assertEqual(('C', 'D'), next(parse))
+        self.assertEqual(MSDParameter(('A', 'B')), next(parse))
+        self.assertEqual(MSDParameter(('C', 'D')), next(parse))
         self.assertRaises(StopIteration, next, parse)
     
     def test_escapes(self):
         parse = parse_msd(string='#A\\:B:C\\;D;#E\\#F:G\\\\H;#LF:\\\nLF;')
 
-        self.assertEqual(('A:B', 'C;D'), next(parse))
-        self.assertEqual(('E#F', 'G\\H'), next(parse))
-        self.assertEqual(('LF', '\nLF'), next(parse))
+        self.assertEqual(MSDParameter(('A:B', 'C;D')), next(parse))
+        self.assertEqual(MSDParameter(('E#F', 'G\\H')), next(parse))
+        self.assertEqual(MSDParameter(('LF', '\nLF')), next(parse))
         self.assertRaises(StopIteration, next, parse)
     
     def test_no_escapes(self):
@@ -164,9 +165,9 @@ class TestParseMSD(unittest.TestCase):
             ignore_stray_text=True,
         )
 
-        self.assertEqual(('A\\', 'B:C\\'), next(parse))
-        self.assertEqual(('E\\#F', 'G\\\\H'), next(parse))
-        self.assertEqual(('LF', '\\\nLF'), next(parse))
+        self.assertEqual(MSDParameter(('A\\', 'B', 'C\\')), next(parse))
+        self.assertEqual(MSDParameter(('E\\#F', 'G\\\\H')), next(parse))
+        self.assertEqual(MSDParameter(('LF', '\\\nLF')), next(parse))
         self.assertRaises(StopIteration, next, parse)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a big, breaking change to address a discrepancy I recently noticed in how unescaped colons (`:`) after a `#KEY:` are handled by StepMania and msdparser. StepMania splits the string on _every_ colon - not just the first - and takes the second element (index `[1]`) as the value for most properties. In contrast, I chose to simplify the `MSDParameter` API by splitting on only the first colon, providing the rest of the parameter as a single string. Unfortunately, in the presence of unescaped colons, this misrepresents the true value (the one StepMania sees) of almost all important fields, with only three exceptions (these are now documented as well).

The breaking change here is that `MSDParameter` is no longer a subclass of `NamedTuple`, but a `dataclass` containing a single `components: Sequence[str]` attribute (plus `.key` and `.value` properties that access `components[0]` and `[1]`). Unfortunately, this means you can no longer iterate over parameters using `for key, value in parse_msd(...)`. However, this means of unpacking required client code to handle colons on its own - and msdparser's primary client library, [garcia/simfile](https://github.com/garcia/simfile), was not doing it right for most fields.

So, why not fix this in garcia/simfile? msdparser is intended to be usable for other Python applications, and handling values the same way that StepMania handles them is the only way to make the library operate correctly when used intuitively. Forcing clients to discard anything after a colon for the vast majority of values would be a major (and avoidable!) foot-gun.

Here is the new "Hello World" example in the updated docs and readme:

```python
>>> from msdparser import parse_msd
>>> with open('testdata/Springtime.ssc', 'r', encoding='utf-8') as simfile:
...     for param in parse_msd(file=simfile):
...         if param.key == 'NOTEDATA': break   # stop at the first chart
...         if not param.value: continue        # hide empty values
...         print(param.key, '=', repr(param.value))
...
VERSION = '0.83'
TITLE = 'Springtime'
ARTIST = 'Kommisar'
BANNER = 'springbn.png'
BACKGROUND = 'spring.png'
MUSIC = 'Kommisar - Springtime.mp3'
OFFSET = '-0.090'
SAMPLESTART = '105.760'
SAMPLELENGTH = '15'
SELECTABLE = 'YES'
DISPLAYBPM = '182'
BPMS = '0=181.685'
TIMESIGNATURES = '0=4=4'
TICKCOUNTS = '0=2'
COMBOS = '0=1'
SPEEDS = '0=1=0=0'
SCROLLS = '0=1'
LABELS = '0=Song Start'
```

This is reflected in the updated documentation & readme. For parameters that are known to have multiple `:`-separated values, client code can use `param.components` to access the full sequence of string components.