### PR TITLE
Separate lexer from parser & iterate on chunks

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,3 +65,12 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+autoapi_type = 'python'
+autoapi_dirs = ['../../msdparser']
+autoapi_ignore = ['*tests*', '*_private*']
+autoapi_options = [
+    'members', 'undoc-members', 'show-inheritance', 'show-module-summary',
+    'imported-members',
+]
+autodoc_member_order = 'bysource'

--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -5,14 +5,14 @@ MSD is a key-value store, similar in function to INI files. `Here is an example 
 
 In general, MSD key-value pairs look like ``#KEY:VALUE;`` - the ``#`` starts a parameter, the first ``:`` separates the key from the value, and the ``;`` terminates the value. Keys don't have to be unique - for example, each chart in an SM file uses the same ``NOTES`` key.
 
-Comments start with ``//`` and persist until the end of the line. They can appear anywhere, including inside values (or even keys).
+Comments start with ``//`` and persist until the end of the line. They can appear anywhere, including inside values (or even keys, technically).
 
 Escape sequences
 ~~~~~~~~~~~~~~~~
 
 Modern applications of MSD have *escape sequences*: any special character (``:``, ``;``, ``\``) or comment initializer (``//``) can be treated as literal text by prefixing it with a ``\``. This behavior is enabled by default.
 
-Older applications treat backslashes as regular text, and thus do not permit a literal ``;`` in keys or values, nor ``:`` in keys. This behavior can be replicated by passing ``escapes=False`` to :func:`.parse_msd` or :meth:`.MSDParameter.serialize`.
+Older applications treat backslashes as regular text, and thus do not permit a literal ``:`` or ``;`` in keys or values. This behavior can be replicated by passing ``escapes=False`` to :func:`.parse_msd`, :func:`.lex_msd`, or :meth:`.MSDParameter.serialize`.
 
 Refer to the table below to decide whether escapes should be left enabled or explicitly disabled:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,8 @@ Parsing
     SCROLLS = '0=1'
     LABELS = '0=Song Start'
 
+For simplicity, this function discards comments and whitespace between parameters. If this extra information is desired, :func:`.lex_msd` offers a lower-level alternative.
+
 Serializing
 -----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@ Simple MSD parser for Python. MSD is the underlying file format for a few rhythm
 Parsing
 -------
 
-:func:`.parse_msd` takes a named `file` or `string` argument and yields :class:`MSDParameter` instances:
+:func:`.parse_msd` takes a named `file` or `string` argument and yields :class:`.MSDParameter` instances:
 
 .. doctest::
 

--- a/msdparser/__init__.py
+++ b/msdparser/__init__.py
@@ -5,7 +5,7 @@ import enum
 from functools import reduce
 from io import StringIO
 import re
-from typing import Iterator, List, Optional, Pattern, Sequence, TextIO, Tuple, Union
+from typing import Iterator, List, Optional, Pattern, Sequence, TextIO, Tuple
 
 
 __all__ = ['MSDParserError', 'MSDParameter', 'MSDToken', 'parse_msd', 'lex_msd']
@@ -165,13 +165,9 @@ class MSDToken(enum.Enum):
     COMMENT = enum.auto()
 
 
-ALL_METACHARACTERS = ':;/#\\'
-HAS_METACHARACTERS = re.compile(f'[{re.escape(ALL_METACHARACTERS)}]')
-
-
 def parse_msd(
     *,
-    file: Optional[Union[TextIO, Iterator[str]]] = None,
+    file: Optional[TextIO] = None,
     string: Optional[str] = None,
     escapes: bool = True,
     ignore_stray_text: bool = False

--- a/msdparser/__init__.py
+++ b/msdparser/__init__.py
@@ -1,12 +1,11 @@
 __version__ = '2.0.0-beta.2'
 
-from ast import Str
 from dataclasses import dataclass
 import enum
 from functools import reduce
 from io import StringIO
 import re
-from typing import Generator, Iterable, Iterator, List, NamedTuple, Optional, Pattern, Sequence, TextIO, Tuple, Union
+from typing import Iterator, List, Optional, Pattern, Sequence, TextIO, Tuple, Union
 
 
 __all__ = ['MSDParserError', 'MSDParameter', 'MSDToken', 'parse_msd', 'lex_msd']

--- a/msdparser/tests/test_module.py
+++ b/msdparser/tests/test_module.py
@@ -1,8 +1,8 @@
-from typing import Tuple
+from typing import Iterator, Tuple
 import unittest
 from io import StringIO
 
-from msdparser import MSDParameter, MSDParserError, parse_msd
+from msdparser import MSDParameter, MSDParserError, MSDToken, parse_msd, lex_msd
 
 
 class TestMSDParameter(unittest.TestCase):
@@ -171,6 +171,25 @@ class TestParseMSD(unittest.TestCase):
         self.assertEqual(MSDParameter(('E\\#F', 'G\\\\H')), next(parse))
         self.assertEqual(MSDParameter(('LF', '\\\nLF')), next(parse))
         self.assertRaises(StopIteration, next, parse)
+
+
+class TestLexMSD(unittest.TestCase):
+
+    def test_tokens(self):
+        lexer = lex_msd(string='#ABC:DEF\\:GHI;\n#JKL:MNO\nPQR STU')
+
+        self.assertEqual((MSDToken.POUND, '#'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'ABC'), next(lexer))
+        self.assertEqual((MSDToken.COLON, ':'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'DEF:GHI'), next(lexer))
+        self.assertEqual((MSDToken.SEMICOLON, ';'), next(lexer))
+        self.assertEqual((MSDToken.WHITESPACE, '\n'), next(lexer))
+        self.assertEqual((MSDToken.POUND, '#'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'JKL'), next(lexer))
+        self.assertEqual((MSDToken.COLON, ':'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'MNO\nPQR STU'), next(lexer))
+        self.assertRaises(StopIteration, next, lexer)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/msdparser/tests/test_module.py
+++ b/msdparser/tests/test_module.py
@@ -176,18 +176,20 @@ class TestParseMSD(unittest.TestCase):
 class TestLexMSD(unittest.TestCase):
 
     def test_tokens(self):
-        lexer = lex_msd(string='#ABC:DEF\\:GHI;\n#JKL:MNO\nPQR STU')
+        lexer = lex_msd(string='#ABC:DEF\\:GHI;\n#JKL:MNO\nPQR# STU')
 
-        self.assertEqual((MSDToken.POUND, '#'), next(lexer))
+        self.assertEqual((MSDToken.START_PARAMETER, '#'), next(lexer))
         self.assertEqual((MSDToken.TEXT, 'ABC'), next(lexer))
-        self.assertEqual((MSDToken.COLON, ':'), next(lexer))
-        self.assertEqual((MSDToken.TEXT, 'DEF:GHI'), next(lexer))
-        self.assertEqual((MSDToken.SEMICOLON, ';'), next(lexer))
-        self.assertEqual((MSDToken.WHITESPACE, '\n'), next(lexer))
-        self.assertEqual((MSDToken.POUND, '#'), next(lexer))
+        self.assertEqual((MSDToken.NEXT_COMPONENT, ':'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'DEF'), next(lexer))
+        self.assertEqual((MSDToken.ESCAPE, '\\:'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'GHI'), next(lexer))
+        self.assertEqual((MSDToken.END_PARAMETER, ';'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, '\n'), next(lexer))
+        self.assertEqual((MSDToken.START_PARAMETER, '#'), next(lexer))
         self.assertEqual((MSDToken.TEXT, 'JKL'), next(lexer))
-        self.assertEqual((MSDToken.COLON, ':'), next(lexer))
-        self.assertEqual((MSDToken.TEXT, 'MNO\nPQR STU'), next(lexer))
+        self.assertEqual((MSDToken.NEXT_COMPONENT, ':'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'MNO\nPQR# STU'), next(lexer))
         self.assertRaises(StopIteration, next, lexer)
 
 

--- a/msdparser/tests/test_module.py
+++ b/msdparser/tests/test_module.py
@@ -137,13 +137,33 @@ class TestParseMSD(unittest.TestCase):
         parse = parse_msd(string='#A:B;n#C:D;')
 
         self.assertEqual(MSDParameter(('A', 'B')), next(parse))
-        self.assertRaises(MSDParserError, next, parse)
+        self.assertRaisesRegex(
+            MSDParserError,
+            "stray 'n' encountered after 'A' parameter",
+            next,
+            parse,
+        )
+    
+    def test_stray_text_at_start(self):
+        parse = parse_msd(string='TITLE:oops;')
+
+        self.assertRaisesRegex(
+            MSDParserError,
+            "stray 'T' encountered at start of document",
+            next,
+            parse,
+        )
     
     def test_stray_semicolon(self):
         parse = parse_msd(string='#A:B;;#C:D;')
 
         self.assertEqual(MSDParameter(('A', 'B')), next(parse))
-        self.assertRaises(MSDParserError, next, parse)
+        self.assertRaisesRegex(
+            MSDParserError,
+            "stray ';' encountered after 'A' parameter",
+            next,
+            parse,
+        )
     
     def test_stray_text_with_ignore_stray_text(self):
         parse = parse_msd(string='#A:B;n#C:D;', ignore_stray_text=True)

--- a/msdparser/tests/test_module.py
+++ b/msdparser/tests/test_module.py
@@ -191,6 +191,23 @@ class TestLexMSD(unittest.TestCase):
         self.assertEqual((MSDToken.NEXT_COMPONENT, ':'), next(lexer))
         self.assertEqual((MSDToken.TEXT, 'MNO\nPQR# STU'), next(lexer))
         self.assertRaises(StopIteration, next, lexer)
+    
+    def test_tokens_without_escapes(self):
+        lexer = lex_msd(string='#ABC:DEF\\:GHI;\n#JKL:MNO\nPQR# STU', escapes=False)
+
+        self.assertEqual((MSDToken.START_PARAMETER, '#'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'ABC'), next(lexer))
+        self.assertEqual((MSDToken.NEXT_COMPONENT, ':'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'DEF\\'), next(lexer))
+        self.assertEqual((MSDToken.NEXT_COMPONENT, ':'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'GHI'), next(lexer))
+        self.assertEqual((MSDToken.END_PARAMETER, ';'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, '\n'), next(lexer))
+        self.assertEqual((MSDToken.START_PARAMETER, '#'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'JKL'), next(lexer))
+        self.assertEqual((MSDToken.NEXT_COMPONENT, ':'), next(lexer))
+        self.assertEqual((MSDToken.TEXT, 'MNO\nPQR# STU'), next(lexer))
+        self.assertRaises(StopIteration, next, lexer)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
MSD parsing is now a two-function affair, with `lex_msd` supplying the basic lexical tokens for `parse_msd` to convert into parameters.

There are a few motivations behind this change:

* Previously, there was no way to preserve whitespace & comments when using this library. Having a separate lexer enables this kind of low-level manipulation.
* The unified parser was rather complex, which made it difficult to optimize for speed. Splitting it into two functions enabled the core lexer to be rewritten for maximum performance.
* The source code for `parse_msd` is now quite legible & serves as a reference implementation for consuming the output of `lex_msd`.

Most of the performance gains can be attributed to reading the input in 4 KB _chunks_, rather than line-by-line, and by operating on strings of _semantically uniform text_, rather than characters. Since MSD documents tend to have many lines proportional to their size, iterating over lines tends to bog down the parser with unnecessary loops, especially considering note data (the largest component in most applications of MSD) is a semantically uniform chunk of text with very few special characters.

I also improved the error message for `MSDParserError` as commiseration for #6 being obsoleted by this changeset. Offering the last parameter's key isn't quite as helpful as a line & column, but it should be enough to help track down a stray character in most cases.